### PR TITLE
Found_trades and possible_trades now have a status field

### DIFF
--- a/models/init.js
+++ b/models/init.js
@@ -15,7 +15,7 @@ exports.create_tables = function(){
         }
         var queries = ['CREATE TABLE IF NOT EXISTS owned_books(user_id VARCHAR, book_id INTEGER, PRIMARY KEY (user_id, book_id))',
                        'CREATE TABLE IF NOT EXISTS wish_list(user_id VARCHAR, book_id INTEGER, PRIMARY KEY (user_id, book_id))',
-                       'CREATE TABLE IF NOT EXISTS possible_trades(user_id VARCHAR, book_have INTEGER, book_want INTEGER, PRIMARY KEY (user_id, book_have, book_want))',
+                       'CREATE TABLE IF NOT EXISTS possible_trades(user_id VARCHAR, book_have INTEGER, book_want INTEGER, status VARCHAR(1), PRIMARY KEY (user_id, book_have, book_want))',
                        'CREATE TABLE IF NOT EXISTS graph_edges(user_id VARCHAR, book_have INTEGER, target_id VARCHAR, book_want INTEGER, PRIMARY KEY (user_id, book_have, target_id, book_want))',
                        'CREATE TABLE IF NOT EXISTS books(book_id INTEGER, book_name VARCHAR, class_name VARCHAR, PRIMARY KEY (book_id))',
                        'CREATE TABLE IF NOT EXISTS users(user_id VARCHAR, user_name VARCHAR, user_email VARCHAR, PRIMARY KEY (user_id))',

--- a/models/init.js
+++ b/models/init.js
@@ -19,7 +19,7 @@ exports.create_tables = function(){
                        'CREATE TABLE IF NOT EXISTS graph_edges(user_id VARCHAR, book_have INTEGER, target_id VARCHAR, book_want INTEGER, PRIMARY KEY (user_id, book_have, target_id, book_want))',
                        'CREATE TABLE IF NOT EXISTS books(book_id INTEGER, book_name VARCHAR, class_name VARCHAR, PRIMARY KEY (book_id))',
                        'CREATE TABLE IF NOT EXISTS users(user_id VARCHAR, user_name VARCHAR, user_email VARCHAR, PRIMARY KEY (user_id))',
-                       'CREATE TABLE IF NOT EXISTS found_trades(trade_id INTEGER, user_id VARCHAR, book_have INTEGER, target_id VARCHAR, book_want INTEGER, PRIMARY KEY (trade_id, user_id, book_have, target_id, book_want))',
+                       'CREATE TABLE IF NOT EXISTS found_trades(trade_id INTEGER, user_id VARCHAR, book_have INTEGER, target_id VARCHAR, book_want INTEGER, status VARCHAR(1), PRIMARY KEY (trade_id, user_id, book_have, target_id, book_want))',
                        'CREATE TABLE IF NOT EXISTS found_trades_id(index INTEGER,trade_id INTEGER, PRIMARY KEY(index))'];
 
         for(var i = 0; i < queries.length; i++){

--- a/models/possible_trades.js
+++ b/models/possible_trades.js
@@ -137,6 +137,28 @@ exports.get_book_wants = function(user_id, book_have_id, next) {
   });
 };
 
+/*
+ * Get the list of all rows associated with the relation {book_want:book_want_id}
+ * Replies with either an error_code or an Object of Javascript Objects (essentially an array)
+ */
+exports.get_rows_by_want = function(book_want_id, next) {
+    pg.connect(process.env.DATABASE_URL, function(err, client, done){
+        done();
+        if (err){
+            console.error("Error connection to client while querying possible_trades table: ", err);
+            return next(error_codes.possible_trades_errors.DB_CONNECTION_ERROR);
+        }
+
+        client.query("SELECT * FROM possible_trades WHERE book_want=$1::INTEGER", [book_want_id], function(err, result){
+            if(err){
+                console.error("Error querying database", err);
+                return next(error_codes.possible_trades_errors.DB_QUERY_ERROR);
+            }
+            return next(error_codes.possible_trades_errors.DB_SUCCESS, result.rows);
+        });
+    });
+};
+
 
 /*
  * updates status of possible trade {status_id:string length 1, user_id:string , book_have_id:int, book_want_id:int }

--- a/models/possible_trades.js
+++ b/models/possible_trades.js
@@ -182,6 +182,53 @@ exports.update_status = function(status_id, user_id, owned_book, book_want, next
     });
 };
 
+/*
+ * updates status of all possible trades where a user owns
+ * a specific book {status_id:string length 1, user_id:string , book_have_id:int }
+ * Replies with either an error_code
+ */
+exports.update_status_by_owned_book = function(status_id, user_id, owned_book, next) {
+    pg.connect(process.env.DATABASE_URL, function(err, client, done){
+        done();
+        if (err){
+            console.error("Error connection to client while querying possible_trades table: ", err);
+            return next(error_codes.possible_trades_errors.DB_CONNECTION_ERROR);
+        }
+
+        client.query("UPDATE possible_trades SET status=$1::VARCHAR WHERE user_id=$2::VARCHAR AND book_have=$3::INTEGER", [status_id, user_id, owned_book], function(err, result){
+            if(err){
+                console.error("Error querying database", err);
+                return next(error_codes.possible_trades_errors.DB_QUERY_ERROR);
+            }
+            return next(error_codes.possible_trades_errors.DB_SUCCESS);
+        });
+    });
+};
+
+
+/*
+ * updates status of all possible trades where a user wants
+ * a specific book {status_id:string length 1, user_id:string , book_want_id:int }
+ * Replies with either an error_code
+ */
+exports.update_status_by_wanted_book = function(status_id, user_id, book_want_id, next) {
+    pg.connect(process.env.DATABASE_URL, function(err, client, done){
+        done();
+        if (err){
+            console.error("Error connection to client while querying possible_trades table: ", err);
+            return next(error_codes.possible_trades_errors.DB_CONNECTION_ERROR);
+        }
+
+        client.query("UPDATE possible_trades SET status=$1::VARCHAR WHERE user_id=$2::VARCHAR AND book_want=$3::INTEGER", [status_id, user_id, book_want_id], function(err, result){
+            if(err){
+                console.error("Error querying database", err);
+                return next(error_codes.possible_trades_errors.DB_QUERY_ERROR);
+            }
+            return next(error_codes.possible_trades_errors.DB_SUCCESS);
+        });
+    });
+};
+
 
 /*
  * gets status of possible trade { user_id:string , book_have_id:int, book_want_id:int }

--- a/tests/models/found_trades_test.js
+++ b/tests/models/found_trades_test.js
@@ -148,3 +148,41 @@ exports.test_get_id = function(){
         }
     }
 };
+
+exports.update_status_accepted_test = function(){
+    found_trades.update_status_accepted(1,'Adi', 2, 'Jay', 1,next);
+    function next(err, result){
+        if (err == ec.found_trades_id_errors.DB_SUCCESS){
+            console.log("TEST SUCCESS");
+        }
+        else {
+            console.log("TEST FAIL");
+        }
+    }
+};
+
+exports.update_status_rejected_test = function(){
+    found_trades.update_status_rejected(1,'Jay', 1, 'Adi', 2,next);
+    function next(err, result){
+        if (err == ec.found_trades_id_errors.DB_SUCCESS){
+            console.log("TEST SUCCESS");
+        }
+        else {
+            console.log("TEST FAIL");
+        }
+    }
+};
+
+exports.get_statuses_by_id_test = function() {
+    found_trades.get_statuses_by_id(1,next);
+    function next(err, result){
+        if (err == ec.found_trades_id_errors.DB_SUCCESS){
+            console.log("TEST SUCCESS: results below");
+            console.log(result);
+        }
+        else {
+            console.log("TEST FAIL");
+        }
+    }
+};
+

--- a/tests/models/possible_trades.js
+++ b/tests/models/possible_trades.js
@@ -22,7 +22,7 @@ exports.test = function(){
     */
     possibleTrades.add_relation('Jay', 1, 10, test_n_have);
     possibleTrades.add_relation('Jay', 1, 11, test_n_have);
-    possibleTrades.add_relation('Jay', 1, 12, test_n_have); 
+    possibleTrades.add_relation('Jay', 1, 12, test_n_have);
 
     /*
         after this sixth add relation runs, there should be no relations
@@ -57,6 +57,9 @@ exports.test = function(){
         console log should have printed
         [ { book_want: 8 }, { book_want: 9 }, { book_want: 10 } ]
     */
+
+    possibleTrades.update_status('I', 'Jay', 7, 8, test_n);
+    possibleTrades.get_status('Jay', 7, 8, test_next);
   
     function test_n(errorcode){
         if (errorcode == ec.possible_trades_errors.POSSIBLE_TRADE_ALREADY_EXISTS){


### PR DESCRIPTION
Added status field for both found trades an possible_trades. For found trades, the status can take on 'P' for pending, 'A' for accepted, and 'R' for rejected.

For possible_trades, I didnt know the fields it should take, so I made the function flexible in that the api can pass the code it wants to make the status for the possible trade. As of now, when a possible trade is added, the default is 'V' for valid.