### PR TITLE
Responsive fixes

### DIFF
--- a/client/src/components/cardPendingTrade.js
+++ b/client/src/components/cardPendingTrade.js
@@ -36,9 +36,9 @@ class CardPendingTrade extends Component {
     {
         var color = this.props.color
         return (
-            <div className="ctCard" onClick={()=>this.onClickHandler()} style={{backgroundColor: colorMap[color].title}}>
-                <div className="ctTop">
-                    <div className="ctLeft">
+            <div className="ptCard" onClick={()=>this.onClickHandler()} style={{backgroundColor: colorMap[color].title}}>
+                <div className="ptTop">
+                    <div className="ptLeft">
                         <CardImageView 
                             title=""
                             imgUrl={this.props.bookHave.img_url}
@@ -51,7 +51,7 @@ class CardPendingTrade extends Component {
                         <div className="ptAuthor">{this.props.bookHave.author}</div>
                     </div>
                 </div>
-                <div className="ctBottom" style={{backgroundColor: colorMap[color].bottom}}>
+                <div className="ptBottom" style={{backgroundColor: colorMap[color].bottom}}>
                     {this.props.booksWant.length} book{this.props.booksWant.length != 1 ? "s" : ""} wanted in exchange
                 </div>
             </div>

--- a/client/src/components/editTrade.js
+++ b/client/src/components/editTrade.js
@@ -287,7 +287,7 @@ class EditTrade extends Component{
                         <div className="formContents">
                             <h1 className="formTitle">EDIT TRADE</h1>
                             <h3 className="formMessage">Modify the books you want to add to your trades.</h3>
-                            <div className="searchBoxAndResults">
+                            <div className="searchBoxAndResults" ref="editSearchBox">
                                 <SearchBox
                                     onChange={this.processWant}
                                     multi={true}
@@ -302,7 +302,16 @@ class EditTrade extends Component{
                                 </div>
                             </div>
                             <div className="transitionButtonRow">
-                                <button className="formPrev" onClick={()=>this.cancelTrade()}>CANCEL</button>
+                                <button className="formPrev" 
+                                    onClick={
+                                        ()=> {
+                                            this.cancelTrade();
+                                            this.refs.editSearchBox.scrollTop = 0;
+                                        }
+                                    }
+                                >
+                                CANCEL
+                                </button>
                                 {
                                     this.state.want != null &&
                                     this.state.want != this.state.newWant &&
@@ -316,7 +325,7 @@ class EditTrade extends Component{
                      return (
                          <div className="formContents">
                             <h1 className="formTitle">TRADE INFO</h1>
-                            <div className='confirmTradeContainer'>
+                            <div className='confirmTradeContainer' ref="confirmTradeContainer">
                                 <div className='confirmTradeLeft'>
                                     <h4> OFFERING </h4>
                                     <div className="ownedBookSummary">
@@ -329,7 +338,16 @@ class EditTrade extends Component{
                                 </div>
                             </div>
                             <div className="transitionButtonRow">
-                                <button className="formPrev" onClick={()=>this.setPage({option, screen: 2})}>EDIT TRADE</button>
+                                <button className="formPrev" 
+                                    onClick={
+                                        ()=>{
+                                            this.setPage({option, screen: 2});
+                                            this.refs.confirmTradeContainer.scrollTop = 0;
+                                        }
+                                    }
+                                >
+                                EDIT TRADE
+                                </button>
                                 <button className="formNext" onClick={()=>this.deleteTrade()}>DELETE</button>
                             </div>
                          </div>

--- a/client/src/components/form.js
+++ b/client/src/components/form.js
@@ -235,7 +235,7 @@ class Form extends Component{
                         <div className="formContents">
                             <h1 className="formTitle">NEW TRADE</h1>
                             <h3 className="formMessage">Select the book you can offer.</h3>
-                                <div className="ownedBookSearchAndResults">
+                                <div className="ownedBookSearchAndResults" ref="ownedBookSearch">
                                     <div>
                                         <SearchBox
                                             onChange={this.processOffer}
@@ -256,7 +256,16 @@ class Form extends Component{
                             <div className="transitionButtonRow">
                                 {
                                     this.state.offer != null &&
-                                    <button className="formNext" onClick={()=>this.setPage({option, screen: screen+2})}>Next</button>
+                                    <button className="formNext" 
+                                        onClick={
+                                            ()=> {
+                                                this.setPage({option, screen: screen+2});
+                                                this.refs.ownedBookSearch.scrollTop = 0;
+                                            }
+                                        }
+                                    >
+                                    Next
+                                    </button>
                                 }
 
                             </div>
@@ -280,7 +289,7 @@ class Form extends Component{
                         <div className="formContents wantedBooksPage">
                             <h1 className="formTitle">NEW TRADE</h1>
                             <h3 className="formMessage">Select the book(s) you want to receive in return.</h3>
-                            <div className="searchBoxAndResults">
+                            <div className="searchBoxAndResults" ref="wantedBookSearch">
                                 <SearchBox
                                     onChange={this.processWant}
                                     multi={true}
@@ -296,10 +305,28 @@ class Form extends Component{
                                 </div>
                             </div>
                             <div className="transitionButtonRow">
-                                <button className="formPrev" onClick={()=>this.setPage({option, screen: screen-2})}>Previous</button>
+                                <button className="formPrev" 
+                                    onClick={
+                                        ()=>{
+                                            this.setPage({option, screen: screen-2});
+                                            this.refs.wantedBookSearch.scrollTop = 0;
+                                        }
+                                    }
+                                >
+                                Previous
+                                </button>
                                 {
                                     this.state.want != null &&
-                                    <button className="formNext" onClick={()=>this.setPage({option, screen: screen+1})}>Next</button>
+                                    <button className="formNext" 
+                                        onClick={
+                                            ()=>{
+                                                this.setPage({option, screen: screen+1});
+                                                this.refs.wantedBookSearch.scrollTop = 0;
+                                            }
+                                        }
+                                    >
+                                    Next
+                                    </button>
                                 }
                             </div>
                         </div>
@@ -309,7 +336,7 @@ class Form extends Component{
                          <div className="formContents confirmTradePage">
                             <h1 className="formTitle">NEW TRADE</h1>
                             <h3 className="formMessage">Confirm your trades!</h3>
-                            <div className='confirmTradeContainer'>
+                            <div className='confirmTradeContainer' ref="confirmTradeContainer">
                                 <div className='confirmTradeLeft'>
                                     <h4> OFFERING </h4>
                                     <div className="ownedBookSummary">
@@ -317,12 +344,21 @@ class Form extends Component{
                                     </div>
                                 </div>
                                 <div className='confirmTradeRight'>
-                                    <h4> TRADES </h4>
+                                    <h4> WANTED </h4>
                                     <MinSummary books={this.state.want}/>
                                 </div>
                             </div>
                             <div className="transitionButtonRow">
-                                <button className="formPrev" onClick={()=>this.setPage({option, screen: screen-1})}>Previous</button>
+                                <button className="formPrev" 
+                                    onClick={
+                                        ()=>{
+                                            this.setPage({option, screen: screen-1});
+                                            this.refs.confirmTradeContainer.scrollTop = 0;
+                                        }
+                                    }
+                                >
+                                Previous
+                                </button>
                                 <button className="formNext" onClick={()=>this.createTrade("TRADE")}>Create Trade</button>
                             </div>
                          </div>

--- a/client/src/microcomponents/cardDetailView.css
+++ b/client/src/microcomponents/cardDetailView.css
@@ -23,6 +23,8 @@
     font-size: 1.2em;
     color: black;
     text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 img {

--- a/client/src/microcomponents/cardImageView.css
+++ b/client/src/microcomponents/cardImageView.css
@@ -1,16 +1,18 @@
 @media only screen and (min-width : 768px) {
     .ciContainer{
     /*    background-color: cornflowerblue;*/
+        height: 100%;
     }
 
     .ciImageBox{
     /*    background-color: skyblue;*/
-        padding: 12px;
+        padding: 8px;
+        height: 100%;
     }
 
     .ciImage{
         object-fit: contain;
-        height: 16vh;
+        height: 100%;
     }
 }
 

--- a/client/src/styles/cardAdd.css
+++ b/client/src/styles/cardAdd.css
@@ -46,8 +46,8 @@
 
 @media only screen and (max-width : 768px) {
     .cardAdd{
-        height: 20vh;
-        width: 95vw;
+        height: 30vh;
+        width: 90vw;
         background-color: white;
     /*    display: flex;*/
     /*    flex-direction: column;*/
@@ -56,6 +56,7 @@
         margin-bottom: 3%;
         border: 1px solid rgba(0, 0, 0, 0.125);
         border-radius: 0.25rem;
+        box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
     }
 
     .cardAddImage{
@@ -63,7 +64,7 @@
         object-fit: contain;
         max-width: 7vh;
         max-height: 7vh;
-        margin-top: 3vh;
+        margin-top: 8vh;
     }
 
     .cardAddTitle{

--- a/client/src/styles/cardClosedTrade.css
+++ b/client/src/styles/cardClosedTrade.css
@@ -4,7 +4,6 @@
         height: 17vw;
         width: 28vw;
         background-color: white;
-        box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
     /*    display: flex;*/
     /*    flex-direction: column;*/
         border: 1px solid rgba(0, 0, 0, 0.125);
@@ -12,9 +11,7 @@
         margin-left: 1%;
         margin-right: 1%;
         margin-bottom: 3%;
-        padding-top: 1%;
         display: flex;
-        padding-top: 1%;
         flex-direction: column;
     /*    align-items: center;*/
     /*    justify-content: center;*/
@@ -26,39 +23,50 @@
         flex-direction: row;
         align-items: center;
         justify-content: center;
+        width: 100%;
+        height: 100%;
     }
 
     .ctLeft{
         flex: 2;
         margin: 5%;
+        width: 30%;
+        height: 90%;
     }
 
     .ctCenter{
-        width: 50px;
+        /* width: 50px; */
+        width: 20%;
         flex: 1;
     }
 
     .centerImage {
-        width: 50px;
-        height: 50px;
+        width: 100%;
+        height: 100%;
         object-fit: contain;
     }
 
-    .centerHalfLoop{
-        width: 55px;
-        height: 55px;
+    .centerHalfLoop {
+        width: 100%;
+        height: 100%;
         object-fit: contain;
     } 
 
     .ctRight{
         flex: 2;
         margin: 5%;
+        width: 30%;
+        height: 90%;
     }
 
     .ctBottom{
         color: white;
         font-size: 12px;
-        line-height: 30px;
+        padding: 5px;
+    }
+
+    .ctCard .ciImageBox{
+        height: 80%;
     }
 }
 
@@ -66,12 +74,11 @@
     .ctCard{
         box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
         height: 30vh;
-        width: 100vw;
+        width: 95vw;
         background-color: white;
     /*    display: flex;*/
     /*    flex-direction: column;*/
         border: 1px solid rgba(0, 0, 0, 0.125);
-        box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
         border-radius: 0.25rem;
         margin-left: 1%;
         margin-right: 1%;
@@ -120,7 +127,7 @@
     .ctBottom{
         color: white;
         font-size: 12px;
-        line-height: 30px;
+        padding: 5px;
     }
 }
 

--- a/client/src/styles/cardClosedTrade.css
+++ b/client/src/styles/cardClosedTrade.css
@@ -74,7 +74,7 @@
     .ctCard{
         box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
         height: 30vh;
-        width: 95vw;
+        width: 90vw;
         background-color: white;
     /*    display: flex;*/
     /*    flex-direction: column;*/

--- a/client/src/styles/cardClosedTrade.css
+++ b/client/src/styles/cardClosedTrade.css
@@ -60,34 +60,6 @@
         font-size: 12px;
         line-height: 30px;
     }
-
-    .cardImage{
-    /*    border-radius: 5px;*/
-        object-fit: contain;
-        max-width: 6.5vw;
-        max-height: 6.5vw;
-        margin-top: 12%;
-    }
-
-    .cardTitle{
-        flex: 1;
-        padding-top: 0.65vw;
-    /*    background-color: blue;*/
-        font-size: 24px;
-        font-weight: 500;
-        text-align: center;
-        color: grey;
-    }
-
-    .cardSubtitle{
-        flex: 1;
-    /*    background-color: green;*/
-        font-size: 24px;
-        font-weight: 300;
-        text-align: left;
-        line-height: 25px;
-        padding-left: 5px;
-    }
 }
 
 @media only screen and (max-width : 768px) {
@@ -150,34 +122,6 @@
         font-size: 12px;
         line-height: 30px;
     }
-
-    .cardImage{
-    /*    border-radius: 5px;*/
-        object-fit: contain;
-        max-width: 8vw;
-        max-height: 20vh;
-        margin-top: 12%;
-    }
-
-    .cardTitle{
-        flex: 1;
-        padding-top: 0.65vw;
-    /*    background-color: blue;*/
-        font-size: 24px;
-        font-weight: 500;
-        text-align: center;
-        color: grey;
-    }
-
-    .cardSubtitle{
-        flex: 1;
-    /*    background-color: green;*/
-        font-size: 24px;
-        font-weight: 300;
-        text-align: left;
-        line-height: 25px;
-        padding-left: 5px;
-    }
 }
 
 .centerCross {
@@ -185,5 +129,3 @@
     height: 42px;
     object-fit: contain;
 }
-
-

--- a/client/src/styles/cardPendingTrade.css
+++ b/client/src/styles/cardPendingTrade.css
@@ -94,8 +94,8 @@
     .ptLeft{
         flex: 2;
         margin: 5%;
-        width: 50%;
-        height: 100%;
+        width: 40%;
+        height: 90%;
     }
 
     .ptRight{

--- a/client/src/styles/cardPendingTrade.css
+++ b/client/src/styles/cardPendingTrade.css
@@ -1,5 +1,5 @@
 @media only screen and (max-width : 768px) {
-    .ctCard{
+    .ptCard{
         height: 30vh;
         width: 95vw;
         background-color: white;
@@ -18,7 +18,7 @@
 
     }
 
-    .ctTop{
+    .ptTop{
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -27,27 +27,10 @@
         height: 90%;
     }
 
-    .ctLeft{
+    .ptLeft{
         flex: 2;
         margin: 5%;
         width: 50%;
-    }
-
-    .ctCenter{
-        width: 50px;
-        flex: 1;
-    }
-
-    .centerImage {
-        width: 50px;
-        height: 50px;
-        object-fit: contain;
-    }
-
-    .centerHalfLoop{
-        width: 55px;
-        height: 55px;
-        object-fit: contain;
     }
 
     .ptRight{
@@ -67,14 +50,6 @@
         padding-right: 5px;
     }
 
-    .cardImage{
-    /*    border-radius: 5px;*/
-        object-fit: contain;
-        max-width: 6.5vw;
-        max-height: 6.5vw;
-        margin-top: 12%;
-    }
-
     .ptTitle{
         margin-top: -1%;
         padding-bottom: 1%;
@@ -86,30 +61,10 @@
         text-overflow: ellipsis;
         overflow: hidden;
     }
-
-    .cardTitle{
-        flex: 1;
-        padding-top: 0.65vw;
-    /*    background-color: blue;*/
-        font-size: 24px;
-        font-weight: 500;
-        text-align: center;
-        color: grey;
-    }
-
-    .cardSubtitle{
-        flex: 1;
-    /*    background-color: green;*/
-        font-size: 24px;
-        font-weight: 300;
-        text-align: left;
-        line-height: 25px;
-        padding-left: 5px;
-        }
 }
 
 @media only screen and (min-width : 768px) {
-    .ctCard{
+    .ptCard{
         height: 17vw;
         width: 28vw;
         background-color: white;
@@ -127,7 +82,7 @@
 
     }
 
-    .ctTop{
+    .ptTop{
         display: flex;
         flex-direction: row;
         align-items: center;
@@ -136,29 +91,12 @@
         height: 100%;
     }
 
-    .ctLeft{
+    .ptLeft{
         flex: 2;
         margin: 5%;
         width: 50%;
         height: 100%;
     }
-
-    .ctCenter{
-        width: 50px;
-        flex: 1;
-    }
-
-    .centerImage {
-        width: 50px;
-        height: 50px;
-        object-fit: contain;
-    }
-
-    .centerHalfLoop{
-        width: 55px;
-        height: 55px;
-        object-fit: contain;
-    } 
 
     .ptRight{
         flex: 2;
@@ -179,14 +117,6 @@
         line-height: 30px;
     }
 
-    .cardImage{
-    /*    border-radius: 5px;*/
-        object-fit: contain;
-        max-width: 6.5vw;
-        max-height: 6.5vw;
-        margin-top: 12%;
-    }
-
     .ptTitle{
         margin-top: -1%;
         padding-bottom: 1%;
@@ -197,25 +127,5 @@
     .ptAuthor {
         text-overflow: ellipsis;
         overflow: hidden;
-    }
-
-    .cardTitle{
-        flex: 1;
-        padding-top: 0.65vw;
-    /*    background-color: blue;*/
-        font-size: 24px;
-        font-weight: 500;
-        text-align: center;
-        color: grey;
-    }
-
-    .cardSubtitle{
-        flex: 1;
-    /*    background-color: green;*/
-        font-size: 24px;
-        font-weight: 300;
-        text-align: left;
-        line-height: 25px;
-        padding-left: 5px;
     }
 }

--- a/client/src/styles/cardPendingTrade.css
+++ b/client/src/styles/cardPendingTrade.css
@@ -56,6 +56,7 @@
         color: white;
         font-size: 1.5em;
         width: 50%;
+        height: 80%;
         overflow: hidden;
         text-overflow: ellipsis;
     }
@@ -139,6 +140,7 @@
         flex: 2;
         margin: 5%;
         width: 50%;
+        height: 100%;
     }
 
     .ctCenter{
@@ -164,6 +166,7 @@
         color: white;
         font-size: 1.5em;
         width: 50%;
+        height: 100%;
         overflow: hidden;
         text-overflow: ellipsis;
     }

--- a/client/src/styles/cardPendingTrade.css
+++ b/client/src/styles/cardPendingTrade.css
@@ -2,7 +2,7 @@
     .ptCard{
         box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
         height: 30vh;
-        width: 95vw;
+        width: 90vw;
         background-color: white;
     /*    display: flex;*/
     /*    flex-direction: column;*/
@@ -48,7 +48,8 @@
     .ptBottom{
         color: white;
         text-align: center;
-        padding-right: 5px;
+        font-size: 12px;
+        padding: 5px;
     }
 
     .ptTitle{
@@ -114,9 +115,8 @@
     .ptBottom{
         color: white;
         text-align: center;
-        padding-right: 5px;
         font-size: 12px;
-        line-height: 30px;
+        padding: 5px;
     }
 
     .ptTitle{

--- a/client/src/styles/cardPendingTrade.css
+++ b/client/src/styles/cardPendingTrade.css
@@ -1,5 +1,6 @@
 @media only screen and (max-width : 768px) {
     .ptCard{
+        box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
         height: 30vh;
         width: 95vw;
         background-color: white;
@@ -46,7 +47,7 @@
 
     .ptBottom{
         color: white;
-        text-align: right;
+        text-align: center;
         padding-right: 5px;
     }
 
@@ -65,6 +66,7 @@
 
 @media only screen and (min-width : 768px) {
     .ptCard{
+        box-shadow: -5px 5px 20px -5px rgba(0,0,0,0.5);
         height: 17vw;
         width: 28vw;
         background-color: white;
@@ -111,7 +113,7 @@
 
     .ptBottom{
         color: white;
-        text-align: right;
+        text-align: center;
         padding-right: 5px;
         font-size: 12px;
         line-height: 30px;

--- a/client/src/styles/form.css
+++ b/client/src/styles/form.css
@@ -44,7 +44,7 @@
         border-radius: 3px;
         box-shadow: 0 2px 6px rgba(0, 0, 0, 1);
     */
-        width: 100vw;
+        width: 92vw;
         height: 80vh;
         position: relative;
         text-align: center;

--- a/client/src/styles/form.css
+++ b/client/src/styles/form.css
@@ -186,7 +186,8 @@
         flex-direction: row;
         position: relative;
         font-size: 12px;
-        overflow: none;
+        overflow: scroll;
+        height: 70%;
         background-color: rgb(236, 236, 236);
     }
 

--- a/client/src/styles/tradeDetail.css
+++ b/client/src/styles/tradeDetail.css
@@ -1,114 +1,239 @@
-.tdContainer{
-    background-color: #47AFCB;
-    width: 70vw;
-    height: 70vh;
-    align-items: center;
-    justify-content: center;    
+@media only screen and (min-width : 768px) {
+    .tdContainer{
+        background-color: #47AFCB;
+        width: 70vw;
+        height: 70vh;
+        align-items: center;
+        justify-content: center;    
+    }
+
+    /* need this to make sure that setting heights by percentages for child elements works */
+    /*
+    .tdDetailContents {
+        background-color: cadetblue;
+        height: 60%;
+    }
+
+    .tdDetailContainer{
+        height: 80%;
+        background-color: rgb(254, 254, 254);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: row;
+        overflow: auto;
+        padding: 5%;
+    }
+    */
+
+    .tdDetailContainer{
+        width: 85%;
+        min-height: 70%;
+        background-color: white;
+        margin: auto;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: row;
+    }
+
+    .tdDetailTextContainer{
+        background-color: rgb(254, 254, 254);
+        overflow: auto;
+        margin-left: 5%;
+        margin-right: 5%;
+        padding-top: 10%;
+        padding-bottom: 10%;
+        text-align: center;
+        padding-left: 5%;
+        padding-right: 5%;
+    }
+
+    .tdTitle{
+        color: white;
+        text-align: center;
+        padding: 3%;
+        font-size: 2em;
+    }
+
+    .tdLeft{
+        flex: 2;
+        margin: 5%;
+        justify-content: center;
+        align-items: center;
+        width: 30%;
+        height: 100%;
+    }
+
+    .tdCenter{
+        width: 20%;
+        flex: 1;
+        justify-content: center;
+        align-items: center;
+    }
+
+    .tdRight{
+        flex: 2;
+        margin: 5%;
+        justify-content: center;
+        align-items: center;
+        width: 30%;
+        height: 100%;
+    }
+
+    .tdImage {
+        width: 40%;
+    }
+
+    /* navigation buttons */
+    .tdButtonRow {
+        position: absolute;
+        bottom: 5%;
+        text-align: center;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: row;
+        width: 100%;
+    }
+
+    .rejectButton {
+        background-color: #E37449;
+        border: 0px;
+        color: white;
+        margin-top: 3%;
+        padding: 10px;
+        font-size: 1.1em;
+        margin-right: 5%;
+    }
+
+    .acceptButton {
+        background-color: #4BB242;
+        border: 0px;
+        color: white;
+        margin-top: 3%;
+        padding: 10px;
+        font-size: 1.1em;
+    }
 }
 
-/* need this to make sure that setting heights by percentages for child elements works */
-/*
-.tdDetailContents {
-    background-color: cadetblue;
-    height: 60%;
-}
+@media only screen and (max-width : 768px) {
+    .tdContainer{
+        background-color: #47AFCB;
+        width: 100vw;
+        height: 60vh;
+        align-items: center;
+        justify-content: center;    
+    }
 
-.tdDetailContainer{
-    height: 80%;
-    background-color: rgb(254, 254, 254);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: row;
-    overflow: auto;
-    padding: 5%;
-}
-*/
+    /* need this to make sure that setting heights by percentages for child elements works */
+    /*
+    .tdDetailContents {
+        background-color: cadetblue;
+        height: 60%;
+    }
 
-.tdDetailContainer{
-    width: 85%;
-    min-height: 70%;
-    background-color: white;
-    margin: auto;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: row;
-}
+    .tdDetailContainer{
+        height: 80%;
+        background-color: rgb(254, 254, 254);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: row;
+        overflow: auto;
+        padding: 5%;
+    }
+    */
 
-.tdDetailTextContainer{
-    background-color: rgb(254, 254, 254);
-    overflow: auto;
-    margin-left: 5%;
-    margin-right: 5%;
-    padding-top: 10%;
-    padding-bottom: 10%;
-    text-align: center;
-    padding-left: 5%;
-    padding-right: 5%;
-}
+    .tdDetailContainer{
+        width: 85%;
+        min-height: 70%;
+        background-color: white;
+        margin: auto;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: row;
+    }
 
-.tdTitle{
-    color: white;
-    text-align: center;
-    padding: 3%;
-    font-size: 2em;
-}
+    .tdDetailTextContainer{
+        background-color: rgb(254, 254, 254);
+        overflow: auto;
+        margin-left: 5%;
+        margin-right: 5%;
+        padding-top: 10%;
+        padding-bottom: 10%;
+        text-align: center;
+        padding-left: 5%;
+        padding-right: 5%;
+    }
 
-.tdLeft{
-    flex: 2;
-    margin: 5%;
-    justify-content: center;
-    align-items: center;
-}
+    .tdTitle{
+        color: white;
+        text-align: center;
+        padding: 3%;
+        font-size: 2em;
+    }
 
-.tdCenter{
-    width: 5%;
-    flex: 1;
-    justify-content: center;
-    align-items: center;
-}
+    .tdLeft{
+        flex: 2;
+        margin: 5%;
+        justify-content: center;
+        align-items: center;
+        width: 35%;
+        height: 100%;
+    }
 
-.tdRight{
-    flex: 2;
-    margin: 5%;
-    justify-content: center;
-    align-items: center;
-}
+    .tdCenter{
+        width: 10%;
+        flex: 1;
+        justify-content: center;
+        align-items: center;
+    }
 
-.tdImage {
-    width: 40%;
-}
+    .tdRight{
+        flex: 2;
+        margin: 5%;
+        justify-content: center;
+        align-items: center;
+        width: 35%;
+        height: 100%;
+    }
 
-/* navigation buttons */
-.tdButtonRow {
-    position: absolute;
-    bottom: 5%;
-    text-align: center;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-direction: row;
-    width: 100%;
-}
+    .tdImage {
+        width: 40%;
+    }
 
-.rejectButton {
-    background-color: #E37449;
-    border: 0px;
-    color: white;
-    margin-top: 3%;
-    padding: 10px;
-    font-size: 1.1em;
-    margin-right: 5%;
-}
+    /* navigation buttons */
+    .tdButtonRow {
+        position: absolute;
+        bottom: 5%;
+        text-align: center;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-direction: row;
+        width: 100%;
+    }
 
-.acceptButton {
-    background-color: #4BB242;
-    border: 0px;
-    color: white;
-    margin-top: 3%;
-    padding: 10px;
-    font-size: 1.1em;
+    .rejectButton {
+        background-color: #E37449;
+        border: 0px;
+        color: white;
+        margin-top: 3%;
+        padding: 10px;
+        font-size: 1.1em;
+        margin-right: 5%;
+    }
+
+    .acceptButton {
+        background-color: #4BB242;
+        border: 0px;
+        color: white;
+        margin-top: 3%;
+        padding: 10px;
+        font-size: 1.1em;
+    }
 }
 
 

--- a/client/src/styles/tradeDetail.css
+++ b/client/src/styles/tradeDetail.css
@@ -120,7 +120,7 @@
 @media only screen and (max-width : 768px) {
     .tdContainer{
         background-color: #47AFCB;
-        width: 100vw;
+        width: 92vw;
         height: 60vh;
         align-items: center;
         justify-content: center;    


### PR DESCRIPTION
Made the cards on the dashboard and the different pop up pages like tradeDetails, etc. responsive for both desktop and mobile. I wasn't able to test on a 15" laptop but I tried it on my desktop monitor and it worked fine.

I didn't modify the SweetAlert pop ups since they seemed to be pretty responsive on their own, though I did notice that the rejected trade pop up wasn't centered vertically for mobile. It might be related to this if we aren't using SweetAlert 2.0: https://github.com/t4t5/sweetalert/issues/145